### PR TITLE
Switch from `blast` to `iprover` for symmetry proofs

### DIFF
--- a/src/Thorn_Calculus-Core_Bisimilarities.thy
+++ b/src/Thorn_Calculus-Core_Bisimilarities.thy
@@ -1211,7 +1211,7 @@ proof (coinduction arbitrary: P Q R rule: synchronous.symmetric_up_to_rule [wher
         by (intro exI conjI, use in assumption) (fastforce intro: rev_bexI)
     qed
   qed
-qed (respectful, blast)
+qed (respectful, iprover)
 
 end
 

--- a/src/Thorn_Calculus-Semantics-Synchronous.thy
+++ b/src/Thorn_Calculus-Semantics-Synchronous.thy
@@ -1777,7 +1777,7 @@ proof (coinduction arbitrary: P Q rule: synchronous.symmetric_up_to_rule [where 
       using equality_in_universe
       by (intro exI conjI, use in assumption) (fastforce intro: rev_bexI)
   qed
-qed (respectful, blast)
+qed (respectful, iprover)
 
 locale synchronous_transition_system =
   transition_system \<open>transition\<close>


### PR DESCRIPTION
This resolves #60.